### PR TITLE
Define Arduino A pins in GPIO

### DIFF
--- a/arduino/cores/arduino/wiring_digital.cpp
+++ b/arduino/cores/arduino/wiring_digital.cpp
@@ -37,6 +37,14 @@ static coralmicro::Gpio PinNumberToGpio(pin_size_t pinNumber) {
       return coralmicro::Gpio::kArduinoD2;
     case D3:
       return coralmicro::Gpio::kArduinoD3;
+    case A0:
+      return coralmicro::Gpio::kArduinoA0;
+    case A1:
+      return coralmicro::Gpio::kArduinoA1;
+    case A3:
+      return coralmicro::Gpio::kArduinoA3;
+    case A4:
+      return coralmicro::Gpio::kArduinoA4;
     default:
       assert(false);
       return coralmicro::Gpio::kCount;

--- a/libs/base/gpio.cc
+++ b/libs/base/gpio.cc
@@ -569,6 +569,7 @@ void GpioSetMode(Gpio gpio, GpioMode mode) {
   } else {
     pin_config |= PinNameToNoPull[gpio];
   }
+  IOMUXC_SetPinMux(iomuxc[0], iomuxc[1], iomuxc[2], iomuxc[3], iomuxc[4], 1U);
   IOMUXC_SetPinConfig(iomuxc[0], iomuxc[1], iomuxc[2], iomuxc[3], iomuxc[4],
                       pin_config);
 }

--- a/libs/base/gpio.h
+++ b/libs/base/gpio.h
@@ -94,6 +94,10 @@ enum Gpio {
   kArduinoD1 = kUartRts,
   kArduinoD2 = kUartCts,
   kArduinoD3 = kSda6,
+  kArduinoA0 = kAB,
+  kArduinoA1 = kAA,
+  kArduinoA3 = kPwm0,
+  kArduinoA4 = kPwm1,
   // @endcond
 };
 


### PR DESCRIPTION
- Add definitions for the A# pins of Arduino to the GPIO library, so they can be used for general-purpose stuff. Also, set the pin mux to GPIO mode in GpioSetMode (pad config is already being set).