### PR TITLE
Add workflow status badges to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,6 +14,9 @@ The `coralmicro` build system is based on CMake and includes support for Make
 and Ninja builds. After you build the included projects, you can flash
 them to your board with the included flashtool (`scripts/flashtool.py`).
 
+![main](https://github.com/google-coral/coralmicro/actions/workflows/ci.yml/badge.svg?event=push)
+![arduino](https://github.com/google-coral/coralmicro/actions/workflows/arduino.yml/badge.svg?event=push)
+
 
 ## Documentation
 


### PR DESCRIPTION
Add workflow status badges (CI, Arduino) to our README. Only checking the status of the workflows when they're triggered by the `push` action.