### PR TITLE
Skip install arduino in build-flashtool steps.

### DIFF
--- a/.github/workflows/arduino.yml
+++ b/.github/workflows/arduino.yml
@@ -61,7 +61,7 @@ jobs:
         run: bash setup.sh
 
       - name: Build
-        run: bash build.sh -c -a -g
+        run: bash build.sh -c -a -g -i
 
       - uses: actions/upload-artifact@v3
         with:
@@ -89,7 +89,7 @@ jobs:
         run: bash setup.sh
 
       - name: Build
-        run: bash build.sh -c -a -g
+        run: bash build.sh -c -a -g -i
 
       - uses: actions/upload-artifact@v3
         with:


### PR DESCRIPTION
This recent change to [build.sh](https://github.com/google-coral/coralmicro/commit/5e52bb18b5f991e70b6b1ad56b5573bffd22d7fb#diff-4d2a8eefdf2a9783512a35da4dc7676a66404b6f3826a8af9aad038722da6823) requires an explicit `-i` to skip installing arduino, which is causing [this error](https://github.com/google-coral/coralmicro/actions/runs/3292053962) in the arduino ci.

Example passing ci run:
https://github.com/Namburger/coralmicro/actions/runs/3292217462/jobs/5427320507