### PR TITLE
Add .got and .got.plt sections to data segment in linker

### DIFF
--- a/libs/nxp/rt1176-sdk/MIMXRT1176xxxxx_cm7_ram.ld
+++ b/libs/nxp/rt1176-sdk/MIMXRT1176xxxxx_cm7_ram.ld
@@ -363,6 +363,10 @@ SECTIONS
     *(m_usb_dma_init_data)
     *(.data)                 /* .data sections */
     *(.data*)                /* .data* sections */
+    *(.got)
+    *(.got*)
+    *(.got.plt)
+    *(.got.plt*)
     KEEP(*(.jcr*))
     . = ALIGN(4);
     _net_buf_pool_list = .;


### PR DESCRIPTION
- The GOT and PLT need to be copied into their correct location at startup, so bundle them in the same section with .data (which is already copied in the same way).