### PR TITLE
Fix documentation mismatch

### DIFF
--- a/examples/camera_streaming_http/camera_streaming_http.cc
+++ b/examples/camera_streaming_http/camera_streaming_http.cc
@@ -41,7 +41,7 @@ constexpr char kIndexFileName[] = "/coral_micro_camera.html";
 constexpr char kCameraStreamUrlPrefix[] = "/camera_stream";
 
 HttpServer::Content UriHandler(const char* uri) {
-  if (StrEndsWith(uri, "index.shtml")) {
+  if (StrEndsWith(uri, "coral_micro_camera.html")) {
     return std::string(kIndexFileName);
   } else if (StrEndsWith(uri, kCameraStreamUrlPrefix)) {
     // [start-snippet:jpeg]

--- a/examples/camera_streaming_http/camera_streaming_http.cc
+++ b/examples/camera_streaming_http/camera_streaming_http.cc
@@ -41,7 +41,8 @@ constexpr char kIndexFileName[] = "/coral_micro_camera.html";
 constexpr char kCameraStreamUrlPrefix[] = "/camera_stream";
 
 HttpServer::Content UriHandler(const char* uri) {
-  if (StrEndsWith(uri, "coral_micro_camera.html")) {
+  if (StrEndsWith(uri, "index.shtml") ||
+      StrEndsWith(uri, "coral_micro_camera.html")) {
     return std::string(kIndexFileName);
   } else if (StrEndsWith(uri, kCameraStreamUrlPrefix)) {
     // [start-snippet:jpeg]

--- a/examples/wifi_client/wifi_client.cc
+++ b/examples/wifi_client/wifi_client.cc
@@ -25,7 +25,7 @@
 //
 // To build and flash from coralmicro root:
 //    bash build.sh
-//    python3 scripts/flashtool.py -e wifi_server
+//    python3 scripts/flashtool.py -e wifi_client
 
 namespace coralmicro {
 void Main() {


### PR DESCRIPTION
This tiny PR fixes a couple of documentation mismatches in the example applications I found while testing them on the Coral Dev Micro. I have found the examples really valuable to getting started; thank you for including them.