### PR TITLE
Install additional python requirements at build/CI time

### DIFF
--- a/.github/workflows/arduino.yml
+++ b/.github/workflows/arduino.yml
@@ -125,6 +125,7 @@ jobs:
       - name: Build
         run: |
           cmake -B ${{github.workspace}}/build -DCMAKE_BUILD_TYPE=${{env.BUILD_TYPE}} -G Ninja .
+          python.exe -m pip install -r ${{github.workspace}}/scripts/requirements.txt
           python.exe -m pip install -r ${{github.workspace}}/arduino/requirements.txt
           python.exe ${{github.workspace}}/arduino/package.py --output_dir ${{github.workspace}}/build --flashtool
 
@@ -159,6 +160,7 @@ jobs:
 
       - name: Setup Environment
         run: |
+          python -m pip install -r ${{ github.workspace }}/scripts/requirements.txt
           python -m pip install -r ${{ github.workspace }}/arduino/requirements.txt
 
       - name: Build

--- a/build.sh
+++ b/build.sh
@@ -214,6 +214,7 @@ EOF
     fi
 
     if [[ ! -z ${build_arduino} ]]; then
+        python3 -m pip install -r ${SCRIPT_DIR}/scripts/requirements.txt
         python3 -m pip install -r ${SCRIPT_DIR}/arduino/requirements.txt
         if [[ -z ${skip_arduino_flashtool} ]]; then
             python3 ${PACKAGE_PY} --output_dir=${build_dir} --flashtool


### PR DESCRIPTION
Seems like on Windows, PyInstaller silently ignores libraries we passed with --hidden-import if they are not installed: causing our release artifacts to have a broken flashtool.

Add a pip install of the scripts/requirements.txt in build.sh and Arduino build workflows, so that the packages are available for PyInstaller to include.

Verified successful flashing from Windows 10 with the output of this run: https://github.com/atvrager/coralmicro/actions/runs/4471816214