### PR TITLE
Adding support for Aarch64 Linux Host

### DIFF
--- a/cmake/toolchain-arm-none-eabi-gcc.cmake
+++ b/cmake/toolchain-arm-none-eabi-gcc.cmake
@@ -44,7 +44,11 @@ else() # Linux
     set(TOOLCHAIN_PREFIX "")
     set(TOOLCHAIN_ARCHIVE ${TOOLCHAIN_DIR}/toolchain-linux.tar.bz2)
     set(TOOLCHAIN_EXE_EXTENSION "")
-    set(TOOLCHAIN_URL "https://developer.arm.com/-/media/Files/downloads/gnu-rm/9-2020q2/gcc-arm-none-eabi-9-2020-q2-update-x86_64-linux.tar.bz2")
+    if(CMAKE_HOST_SYSTEM_PROCESSOR STREQUAL "x86_64")
+        set(TOOLCHAIN_URL "https://developer.arm.com/-/media/Files/downloads/gnu-rm/9-2020q2/gcc-arm-none-eabi-9-2020-q2-update-x86_64-linux.tar.bz2")
+    elseif(CMAKE_HOST_SYSTEM_PROCESSOR STREQUAL "aarch64")
+        set(TOOLCHAIN_URL "https://developer.arm.com/-/media/Files/downloads/gnu-rm/9-2020q2/gcc-arm-none-eabi-9-2020-q2-update-aarch64-linux.tar.bz2")
+    endif() 
 endif()
 
 if (NOT EXISTS ${TOOLCHAIN_DIR})


### PR DESCRIPTION
I noticed the ARM developer resources provide a binary for compilation from an Aarch64 Linux host so I made a minor change to the CMake configuration to allow compilation on more hosts.