### PR TITLE
Fix scripts dependencies

### DIFF
--- a/scripts/requirements.txt
+++ b/scripts/requirements.txt
@@ -1,5 +1,5 @@
 hexformat==0.2
-hidapi==0.10.1
+hidapi==0.14.0
 progress==1.5
 pyserial==3.5
 pyusb==1.2.0


### PR DESCRIPTION
Getting the following error with `hidapi==0.10.1`, presumably related to the Python version used (3.11). The error goes away when using `hidapi==0.14.0`.

```
Building wheels for collected packages: hidapi
  Building wheel for hidapi (pyproject.toml) ... error
  error: subprocess-exited-with-error

  × Building wheel for hidapi (pyproject.toml) did not run successfully.
  │ exit code: 1
  ╰─> [9 lines of output]
      running bdist_wheel
      running build
      running build_ext
      /private/var/folders/g2/j9ttk5916w7dchg1kv7ry7wm0000gn/T/pip-build-env-kq4oqvl0/normal/lib/python3.11/site-packages/Cython/Compiler/Main.py:381: FutureWarning: Cython directive 'language_level' not set, using '3str' for now (Py3). This has changed from earlier releases! File: /private/var/folders/g2/j9ttk5916w7dchg1kv7ry7wm0000gn/T/pip-install-sj0qzttp/hidapi_25c5c78699cf4fb38464f255bb8f06b3/hid.pyx
        tree = Parsing.p_module(s, pxd, full_module_name)
      Compiling hid.pyx because it changed.
      [1/1] Cythonizing hid.pyx
      building 'hid' extension
      error: unknown file type '.pxd' (from 'chid.pxd')
      [end of output]

  note: This error originates from a subprocess, and is likely not a problem with pip.
  ERROR: Failed building wheel for hidapi
Failed to build hidapi
ERROR: Could not build wheels for hidapi, which is required to install pyproject.toml-based projects
```