### PR TITLE
Update requirements.txt and setup.sh

### DIFF
--- a/scripts/requirements.txt
+++ b/scripts/requirements.txt
@@ -1,5 +1,5 @@
 hexformat==0.2
-hidapi==0.10.1
+hidapi==0.14.0
 progress==1.5
 pyserial==3.5
 pyusb==1.2.0

--- a/setup.sh
+++ b/setup.sh
@@ -26,14 +26,30 @@ function error {
 }
 
 if [[ "${OS}" == "Linux" ]]; then
-  sudo apt-get update && sudo apt-get -y install \
-    make \
-    cmake \
-    libhidapi-hidraw0 \
-    libusb-1.0-0-dev \
-    libudev-dev \
-    python3-dev \
-    python3-pip
+  # 
+  if [[ -x "$(command -v apt-get)" ]]; then
+    sudo apt-get update && sudo apt-get -y install \
+      make \
+      cmake \
+      libhidapi-hidraw0 \
+      libusb-1.0-0-dev \
+      libudev-dev \
+      python3-dev \
+      python3-pip
+      
+  elif [[ -x "$(command -v yum)" ]]; then
+    sudo yum install \
+      make \
+      cmake \
+      python3-hidapi \
+      libusb1-devel \
+      systemd-devel \
+      python3-devel \
+      python3-pip
+   else
+     echo "Error: No supported package manager found"
+     exit 1
+   fi
 
   if [[ -x "$(command -v udevadm)" ]]; then
     sudo cp "${SCRIPT_DIR}/scripts/99-coral-micro.rules" /etc/udev/rules.d/


### PR DESCRIPTION
Version bump of hidapi needed to fix failures to install hidapi, as for example described here:
https://github.com/google-coral/coralmicro/issues/112

Changes to setup.sh to also support Fedora, works perfectly for me on Fedora 39.